### PR TITLE
feat: add integrated terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ This will launch the editor where you can open, edit, and save files.
 - Open, edit, and save plain text files.
 - Find text within the document (`Ctrl+F`).
 - Replace text throughout the document (`Ctrl+H`).
+- Run shell commands in an integrated terminal (`Ctrl+T`).
 


### PR DESCRIPTION
## Summary
- add Terminal menu and Ctrl+T shortcut to open an integrated command runner
- document terminal feature in README

## Testing
- `python -m py_compile code_editor.py`
- `python code_editor.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9958bc4c8328af42599c91cbcda1