### PR TITLE
Handle headless environments for Tkinter code editor

### DIFF
--- a/code_editor.py
+++ b/code_editor.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 
@@ -111,7 +113,16 @@ class CodeEditor:
 
 
 def main():
-    root = tk.Tk()
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        print("No display detected. This application requires a graphical display.")
+        return
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        print(
+            "Unable to initialize Tk. Ensure a graphical display is available."
+        )
+        return
     editor = CodeEditor(root)
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Check for a display before creating the Tk root window
- Gracefully handle `tk.TclError` when no graphical display is available

## Testing
- `python -m py_compile code_editor.py`
- `pytest -q`
- `python code_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb9a01733883289cfde979033ff7b3