### PR TITLE
Add go to definition feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ This will launch the editor where you can open, edit, and save files.
 - Find text within the document (`Ctrl+F`).
 - Replace text throughout the document (`Ctrl+H`).
 - Run shell commands in an integrated terminal (`Ctrl+T`).
+- Jump to function or class definitions (`F12`).
 


### PR DESCRIPTION
## Summary
- support jumping to function and class definitions with a new F12 shortcut
- document the go to definition feature in the README

## Testing
- `python -m py_compile code_editor.py`
- `python code_editor.py` *(fails gracefully without a display)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4089a0688328a96a0034aed7a0cc