### PR TITLE
Give CLI agent a name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ This will launch the editor where you can open, edit, and save files.
 
 ## AI CLI Coding Agent
 
-A small helper script `ai_cli.py` lets you send prompts to an AI model from the command line.
+A small helper script `ai_cli.py` lets you send prompts to the CodeSmith agent from the command line.
 Set your OpenAI API key in the `OPENAI_API_KEY` environment variable and run:
 
 ```
 python ai_cli.py "Explain recursion"
 ```
 
-The response from the model will be printed to the terminal. The script uses the
+The response from CodeSmith will be printed to the terminal. The script uses the
 `requests` library and the OpenAI Chat Completions API.

--- a/ai_cli.py
+++ b/ai_cli.py
@@ -8,11 +8,20 @@ from typing import List
 import requests
 
 
+AGENT_NAME = "CodeSmith"
+
+
 def _build_payload(prompt: str) -> dict:
     """Create payload for OpenAI Chat Completions API."""
     return {
         "model": "gpt-4o-mini",
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": [
+            {
+                "role": "system",
+                "content": f"You are {AGENT_NAME}, an AI coding assistant.",
+            },
+            {"role": "user", "content": prompt},
+        ],
     }
 
 
@@ -47,7 +56,7 @@ def main(args: List[str]) -> int:
     except RuntimeError as exc:
         print(exc)
         return 1
-    print(answer)
+    print(f"{AGENT_NAME}: {answer}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- introduce a `CodeSmith` identifier for the CLI agent and include its persona in API requests
- mention CodeSmith in documentation and prefix CLI outputs with its name

## Testing
- `python -m py_compile ai_cli.py`
- `pytest`
- `python ai_cli.py` (fails: OPENAI_API_KEY environment variable is not set)


------
https://chatgpt.com/codex/tasks/task_e_68bc46799d7c8328a6fe426c9fe302e3