### PR TITLE
Add question mode to CLI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,12 @@ Set your OpenAI API key in the `OPENAI_API_KEY` environment variable and run:
 python ai_cli.py "Explain recursion"
 ```
 
+By default the CLI runs in **coding** mode for general programming help. Use the
+`--mode qa` option to ask questions specifically about this repository:
+
+```
+python ai_cli.py --mode qa "What does ai_cli.py do?"
+```
+
 The response from CodeSmith will be printed to the terminal. The script uses the
 `requests` library and the OpenAI Chat Completions API.

--- a/ai_cli.py
+++ b/ai_cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Simple CLI tool to interact with an AI coding agent via OpenAI API."""
+import argparse
 import json
 import os
 import sys
@@ -11,21 +12,43 @@ import requests
 AGENT_NAME = "CodeSmith"
 
 
-def _build_payload(prompt: str) -> dict:
+def _gather_codebase() -> str:
+    """Collect contents of repository files for question mode."""
+    parts: List[str] = []
+    for root, _, files in os.walk("."):
+        for name in files:
+            if name.endswith(".py") or name.lower() == "readme.md":
+                path = os.path.join(root, name)
+                try:
+                    with open(path, "r", encoding="utf-8") as fh:
+                        parts.append(f"File: {path}\n{fh.read()}")
+                except OSError:
+                    continue
+    return "\n\n".join(parts)
+
+
+def _build_payload(prompt: str, mode: str) -> dict:
     """Create payload for OpenAI Chat Completions API."""
+    if mode == "qa":
+        context = _gather_codebase()
+        system_content = (
+            f"You are {AGENT_NAME}, an AI assistant answering questions about the NovaAtom codebase."
+        )
+        user_content = f"Repository contents:\n{context}\n\nQuestion: {prompt}"
+    else:
+        system_content = f"You are {AGENT_NAME}, an AI coding assistant."
+        user_content = prompt
+
     return {
         "model": "gpt-4o-mini",
         "messages": [
-            {
-                "role": "system",
-                "content": f"You are {AGENT_NAME}, an AI coding assistant.",
-            },
-            {"role": "user", "content": prompt},
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": user_content},
         ],
     }
 
 
-def query_ai(prompt: str) -> str:
+def query_ai(prompt: str, mode: str) -> str:
     """Send a prompt to the AI model and return the response text."""
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
@@ -37,7 +60,7 @@ def query_ai(prompt: str) -> str:
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         },
-        data=json.dumps(_build_payload(prompt)),
+        data=json.dumps(_build_payload(prompt, mode)),
         timeout=30,
     )
     if response.status_code != 200:
@@ -46,13 +69,23 @@ def query_ai(prompt: str) -> str:
     return data["choices"][0]["message"]["content"].strip()
 
 
-def main(args: List[str]) -> int:
-    if not args:
-        print("Usage: python ai_cli.py 'your prompt'")
-        return 1
-    prompt = " ".join(args)
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description="Interact with the CodeSmith agent")
+    parser.add_argument(
+        "prompt", nargs="+", help="Prompt or question for the agent"
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        choices=["coding", "qa"],
+        default="coding",
+        help="Select 'coding' for general coding help or 'qa' to ask about the repository.",
+    )
+    ns = parser.parse_args(argv)
+
+    prompt = " ".join(ns.prompt)
     try:
-        answer = query_ai(prompt)
+        answer = query_ai(prompt, ns.mode)
     except RuntimeError as exc:
         print(exc)
         return 1


### PR DESCRIPTION
## Summary
- extend `ai_cli.py` with `--mode` flag to switch between coding help and repository Q&A
- add repository content gathering for question mode
- document new CLI modes in README

## Testing
- `python -m py_compile ai_cli.py code_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc47ab6ae883289de8a1908f888ae9