### PR TITLE
Use YaCy search with AI-crafted queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ python ai_cli.py --mode qa "What does ai_cli.py do?"
 
 The response from CodeSmith will be printed to the terminal. The script uses the
 `requests` library and the OpenAI Chat Completions API. For both modes the CLI
-also performs a DuckDuckGo web search for your prompt and feeds the top results
-to the model so that answers can include up-to-date information from the
-internet.
+asks the model to craft a focused search query, runs it against the YaCy search
+engine, and feeds the top results to the model so that answers can include
+up-to-date information from the internet.


### PR DESCRIPTION
## Summary
- Replace DuckDuckGo scraping with YaCy JSON API search
- Ask the model to generate concise search queries before executing search
- Document new search approach in README

## Testing
- `python -m py_compile ai_cli.py code_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc4cc8c6408328a39c7154fed59c39