### PR TITLE
Use CodeSmith for code autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will launch the editor where you can open, edit, and save files.
 - Replace text throughout the document (`Ctrl+H`).
 - Run shell commands in an integrated terminal (`Ctrl+T`).
 - Jump to function or class definitions (`F12`).
-- Autocomplete suggestions for keywords and existing words (`Ctrl+Space`).
+- CodeSmith-powered code autocomplete (`Ctrl+Space`; requires `OPENAI_API_KEY`).
 
 ## AI CLI Coding Agent
 


### PR DESCRIPTION
## Summary
- add CodeSmith-backed code suggestions to the editor's autocomplete
- fall back to keyword-based suggestions when no API key or network
- document new CodeSmith autocomplete feature

## Testing
- `python -m py_compile code_editor.py ai_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc503fe4a08328b4b124d7c427f79b