### PR TITLE
Add snippet context to YaCy search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ python ai_cli.py --mode qa "What does ai_cli.py do?"
 The response from CodeSmith will be printed to the terminal. The script uses the
 `requests` library and the OpenAI Chat Completions API. For both modes the CLI
 asks the model to craft a focused search query, runs it against the YaCy search
-engine, and feeds the top results to the model so that answers can include
-up-to-date information from the internet.
+engine, and feeds the top results — including a short snippet for context — to
+the model so that answers can include up-to-date information from the internet.


### PR DESCRIPTION
## Summary
- Expand YaCy integration to include snippets alongside titles and URLs
- Note snippet inclusion in README

## Testing
- `python -m py_compile ai_cli.py code_editor.py`
- `python ai_cli.py --help`
- `python - <<'PY'
from ai_cli import _web_search
print(_web_search('python'))
PY` *(fails: HTTPSConnectionPool(host='yacy.searchlab.eu', port=443): Read timed out. (read timeout=10))*

------
https://chatgpt.com/codex/tasks/task_e_68bc5192541483289404e129a61dbf6d