### PR TITLE
Allow entering OpenAI API key in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This will launch the editor where you can open, edit, and save files.
 - Replace text throughout the document (`Ctrl+H`).
 - Run shell commands in an integrated terminal (`Ctrl+T`).
 - Jump to function or class definitions (`F12`).
-- CodeSmith-powered code autocomplete (`Ctrl+Space`; requires `OPENAI_API_KEY`).
-- Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu.
+ - CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set.
+ - Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key.
 
 ## AI CLI Coding Agent
 

--- a/code_editor.py
+++ b/code_editor.py
@@ -18,6 +18,8 @@ class CodeEditor:
         self.root.title("Basic Code Editor")
         self._setup_widgets()
         self.file_path = None
+        if not os.environ.get("OPENAI_API_KEY"):
+            self._set_api_key()
 
     def _setup_widgets(self):
         self.text = tk.Text(self.root, wrap="none", undo=True)
@@ -46,6 +48,8 @@ class CodeEditor:
         codesmith_menu = tk.Menu(menubar, tearoff=0)
         codesmith_menu.add_command(label="Ask CodeSmith", command=self.ask_codesmith)
         codesmith_menu.add_command(label="Edit with CodeSmith", command=self.codesmith_edit)
+        codesmith_menu.add_separator()
+        codesmith_menu.add_command(label="Set OpenAI API Key", command=self._set_api_key)
         menubar.add_cascade(label="CodeSmith", menu=codesmith_menu)
 
         self.root.config(menu=menubar)
@@ -57,6 +61,13 @@ class CodeEditor:
         self.root.bind_all("<Control-t>", lambda event: self.open_terminal())
         self.root.bind_all("<F12>", lambda event: self.goto_definition())
         self.root.bind_all("<Control-space>", lambda event: self.show_autocomplete())
+
+    def _set_api_key(self):
+        api_key = simpledialog.askstring(
+            "OpenAI API Key", "Enter your OpenAI API key:", show="*"
+        )
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key.strip()
 
     def new_file(self):
         if self._confirm_discard_changes():


### PR DESCRIPTION
## Summary
- Prompt for OpenAI API key on startup when missing
- Add menu option to update API key and document it in README

## Testing
- `python -m py_compile code_editor.py ai_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5643092c83288b547a8129c12b90