### PR TITLE
Add plugin system for user extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,17 @@ This will launch the editor where you can open, edit, and save files.
 - Replace text throughout the document (`Ctrl+H`).
 - Run shell commands in an integrated terminal (`Ctrl+T`).
 - Jump to function or class definitions (`F12`).
- - CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set.
- - Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key.
+- CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set.
+- Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key.
+- Load custom extensions from the `extensions/` directory to add new commands.
+
+## Extensions
+
+Place Python files in an `extensions/` directory alongside `code_editor.py`. Each
+file should define a `register(editor)` function that receives the
+`CodeEditor` instance. Use this hook to add menu items or otherwise customize
+the editor. See `extensions/word_count.py` for an example that adds a simple
+word count command.
 
 ## AI CLI Coding Agent
 

--- a/extensions/word_count.py
+++ b/extensions/word_count.py
@@ -1,0 +1,11 @@
+import re
+from tkinter import messagebox
+
+
+def register(editor):
+    def count_words():
+        content = editor.text.get("1.0", "end")
+        words = re.findall(r"\b\w+\b", content)
+        messagebox.showinfo("Word Count", f"{len(words)} words")
+
+    editor.add_extension_command("Word Count", count_words)


### PR DESCRIPTION
## Summary
- load extension modules from a new `extensions/` directory and expose an Extensions menu
- add helper to register extension commands and a sample word count plugin
- document how to build custom extensions

## Testing
- `python -m py_compile code_editor.py extensions/word_count.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a34bdfc83289d49dc6bd1e39c7f