### PR TITLE
Add simple web-based editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 # NovaAtom
 
-This repository contains a basic code editor built with Tkinter.
+This repository contains a basic code editor built with Tkinter and a simple
+web-based variant.
 
 ## Usage
+
+### Desktop editor
 
 ```
 python code_editor.py
 ```
 
-This will launch the editor where you can open, edit, and save files.
+This will launch the desktop editor where you can open, edit, and save files.
+
+### Web editor
+
+```
+python web_editor.py
+```
+
+Open <http://localhost:5000> in your browser to edit files. The web version
+offers basic editing features but does **not** include CodeSmith.
 
 ## Features
 
@@ -17,8 +29,9 @@ This will launch the editor where you can open, edit, and save files.
 - Replace text throughout the document (`Ctrl+H`).
 - Run shell commands in an integrated terminal (`Ctrl+T`).
 - Jump to function or class definitions (`F12`).
-- CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set.
-- Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key.
+- CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set. *(Desktop only)*
+- Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key. *(Desktop only)*
+- Basic web-based editor accessible at `http://localhost:5000` when running `web_editor.py`.
 - Load custom extensions from the `extensions/` directory to add new commands.
 
 ## Extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.0.0
+flask>=2.0.0

--- a/web_editor.py
+++ b/web_editor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import os
+from flask import Flask, request, render_template_string, jsonify
+
+app = Flask(__name__)
+
+EDITOR_HTML = """
+<!doctype html>
+<title>NovaAtom Web Editor</title>
+<textarea id="editor" style="width:100%;height:80vh;">{{ content }}</textarea>
+<div style="margin-top:10px;">
+  <input id="path" type="text" value="{{ path }}" placeholder="File path" style="width:70%;"/>
+  <button onclick="save()">Save</button>
+</div>
+<script>
+function save() {
+  fetch('/save', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({path: document.getElementById('path').value, content: document.getElementById('editor').value})
+  }).then(resp => resp.json()).then(data => alert(data.message || data.status));
+}
+</script>
+"""
+
+@app.route('/')
+def index():
+    path = request.args.get('path', '')
+    content = ''
+    if path:
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except Exception:
+            content = ''
+    return render_template_string(EDITOR_HTML, content=content, path=path)
+
+@app.route('/save', methods=['POST'])
+def save_file():
+    data = request.get_json(force=True)
+    path = data.get('path')
+    content = data.get('content', '')
+    if not path:
+        return jsonify({'status': 'error', 'message': 'No path provided'}), 400
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return jsonify({'status': 'ok', 'message': 'File saved'})
+    except Exception as exc:
+        return jsonify({'status': 'error', 'message': str(exc)}), 500
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(debug=True, port=port)


### PR DESCRIPTION
## Summary
- add Flask-based `web_editor.py` for basic browser editing
- document web editor usage and note CodeSmith is desktop only
- include Flask in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile code_editor.py web_editor.py ai_cli.py extensions/word_count.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc916992508328b05250df7320093d