### PR TITLE
feat: enable optional CodeSmith terminal access

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ offers basic editing features but does **not** include CodeSmith.
 - Jump to function or class definitions (`F12`).
 - CodeSmith-powered code autocomplete (`Ctrl+Space`). The editor prompts for your OpenAI API key if it isn't set. *(Desktop only)*
 - Ask questions or apply edits with CodeSmith directly from the editor via the **CodeSmith** menu, which also lets you update your API key. *(Desktop only)*
+- When enabled in **CodeSmith > Settings**, CodeSmith can craft and run terminal commands on your behalf.
 - Basic web-based editor accessible at `http://localhost:5000` when running `web_editor.py`.
 - Load custom extensions from the `extensions/` directory to add new commands.
 


### PR DESCRIPTION
## Summary
- add CodeSmith menu option to run terminal commands
- gate command execution behind user-controlled setting
- document terminal capability in README

## Testing
- `python -m py_compile code_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc92bf9a4c8328bb4beda6411a19a6